### PR TITLE
Add a script to allow focusing on a year

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,14 +1,17 @@
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Watertable</title>
     <link rel='stylesheet' href='style.css'>
+    <script src="/script.js" defer></script>
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Lexend&display=swap');
-        </style> 
+    </style>
 </head>
+
 <body>
     <h1>North Pender Island Water Table</h1>
     <div class="summary">
@@ -20,8 +23,12 @@
         <p class="right-col">feet below the surface.</p>
     </div>
     <div class="graph-wrapper">
-        <img id="large" src="/output.svg" alt="A graph showing the water level for this year, and 10 years in the past">
-        <img id="small" src="/output_small.svg" alt="A graph showing the water level for this year, and 10 years in the past">
+        <object id="large" type="image/svg+xml" data="/output.svg"
+            alt="A graph showing the water level for this year, and 10 years in the past"
+            onload="largeGraphLoad()"></object>
+        <object id="small" type="image/svg+xml" data="/output_small.svg"
+            alt="A graph showing the water level for this year, and 10 years in the past"
+            onload="smallGraphLoad()"></object>
         <p style="display:none">Time range: 2010 - 2021<br>
             Smoothing: 48 hours<br>
             AI prediction: no<br>
@@ -35,4 +42,5 @@
         <p id="importance" class="dyn-important">IMPORTANT</p>
     </div>
 </body>
+
 </html>

--- a/www/script.js
+++ b/www/script.js
@@ -1,7 +1,22 @@
+function largeGraphLoad() {
+	graphLoad('large');
+}
+
+function smallGraphLoad() {
+	graphLoad('small');
+}
+
+function graphLoad(graphId) {
+	// We don't actually care what happens to this. It's only acted upon by
+	// event listeners so why give it a variable?
+	new GraphParser(graphId)
+}
+
 class GraphParser {
 	constructor(graphId) {
 		this.graph = document.getElementById(graphId).contentDocument;
 		this.yearLines = this.parseLegend();
+		this.parseGraphLines();
 	}
 
 	parseLegend() {

--- a/www/scripts.js
+++ b/www/scripts.js
@@ -33,13 +33,16 @@ class GraphParser {
 			// Why createElementNS? https://stackoverflow.com/a/61236874
 			let rect = this.graph.createElementNS('http://www.w3.org/2000/svg', 'rect');
 
+			rect.year = year;
 			rect.setAttribute('x', patchBounds.x);
 			rect.setAttribute('y', patchBounds.y + (rectHeight * i));
 			rect.setAttribute('width', patchBounds.width);
 			rect.setAttribute('height', rectHeight);
 			rect.setAttribute('stroke-width', '1');
 			rect.setAttribute('stroke', 'black');
-			rect.setAttribute('fill', 'none');
+			rect.setAttribute('fill', 'transparent');
+
+			rect.onclick = this.clickCallback.bind(this);
 
 			legend.appendChild(rect);
 
@@ -76,9 +79,32 @@ class GraphParser {
 		}
 	}
 
+	clickCallback(clickEvent) {
+		this.unfocusAll();
+		this.setFocus(true, clickEvent.target.year);
+	}
+
 	unfocusAll() {
 		for (let yearLine of this.yearLines) {
 			yearLine.unfocus();
+		}
+	}
+
+	focusAll() {
+		for (let yearLine of this.yearLines) {
+			yearLine.focus();
+		}
+	}
+
+	setFocus(isFocused, year) {
+		for (let yearLine of this.yearLines) {
+			if (yearLine.year == year) {
+				if (isFocused) {
+					yearLine.focus();
+				} else {
+					yearLine.unfocus();
+				}
+			}
 		}
 	}
 }

--- a/www/scripts.js
+++ b/www/scripts.js
@@ -1,0 +1,59 @@
+class GraphParser {
+	constructor(graphId) {
+		this.graph = document.getElementById(graphId).contentDocument;
+		this.yearLines = this.parseLegend();
+	}
+
+	parseLegend() {
+		let legend = this.graph.getElementById('legend_1');
+
+		// The legend is a weird size so get the patch to find the bounds.
+		let patch = this.graph.getElementById('patch_7');
+		let patchBounds = patch.getBBox();
+
+		// Each element consists of a line (first) and the year label (second).
+		// Subtracting one here to not include the patch
+		let lines = (legend.children.length - 1) / 2;
+
+		let rectHeight = patchBounds.height / lines;
+
+		let yearLines = [];
+		for (let i = 0; i < lines; ++i) {
+			// Adding one here to skip the leading `patch`
+			let legendIdx = 1 + (i * 2);
+
+			// We get the group and then the path
+			let line = legend.children[legendIdx].children[0];
+			let label = legend.children[legendIdx + 1];
+
+			// The comment with the year is positioned predictably
+			let year = label.innerHTML.trim().substr(5, 4);
+			let lineColor = line.style.stroke;
+
+			// Why createElementNS? https://stackoverflow.com/a/61236874
+			let rect = this.graph.createElementNS('http://www.w3.org/2000/svg', 'rect');
+
+			rect.setAttribute('x', patchBounds.x);
+			rect.setAttribute('y', patchBounds.y + (rectHeight * i));
+			rect.setAttribute('width', patchBounds.width);
+			rect.setAttribute('height', rectHeight);
+			rect.setAttribute('stroke-width', '1');
+			rect.setAttribute('stroke', 'black');
+			rect.setAttribute('fill', 'none');
+
+			legend.appendChild(rect);
+
+			yearLines.push(new YearLine(year, lineColor, rect));
+		}
+
+		return yearLines;
+	}
+}
+
+class YearLine {
+	constructor(year, lineColor, clickRect) {
+		this.year = year;
+		this.lineColor = lineColor;
+		this.clickRect = clickRect;
+	}
+}

--- a/www/scripts.js
+++ b/www/scripts.js
@@ -48,6 +48,39 @@ class GraphParser {
 
 		return yearLines;
 	}
+
+	parseGraphLines() {
+		let axes = this.graph.getElementById('axes_1');
+
+		for (let i = 0; i < this.yearLines.length; ++i) {
+			// Before the graph lines is the background for the graph and both
+			// axis rule lines
+			let axesIdx = 3 + i;
+
+			// Get the group and then the graph line
+			let graphLine = axes.children[axesIdx].children[0];
+			let graphLineColor = graphLine.style.stroke;
+
+			let foundYearLine = false;
+			for (let yearLine of this.yearLines) {
+				if (yearLine.lineColor == graphLineColor) {
+					yearLine.setGraphLine(graphLine);
+					foundYearLine = true;
+					break;
+				}
+			}
+
+			if (!foundYearLine) {
+				console.log("Failed to find yearLine for color " + graphLineColor);
+			}
+		}
+	}
+
+	unfocusAll() {
+		for (let yearLine of this.yearLines) {
+			yearLine.unfocus();
+		}
+	}
 }
 
 class YearLine {
@@ -55,5 +88,17 @@ class YearLine {
 		this.year = year;
 		this.lineColor = lineColor;
 		this.clickRect = clickRect;
+	}
+
+	setGraphLine(line) {
+		this.graphLine = line;
+	}
+
+	unfocus() {
+		this.graphLine.style.opacity = "0.1";
+	}
+
+	focus() {
+		this.graphLine.style.opacity = "1";
 	}
 }

--- a/www/scripts.js
+++ b/www/scripts.js
@@ -26,27 +26,24 @@ class GraphParser {
 			let line = legend.children[legendIdx].children[0];
 			let label = legend.children[legendIdx + 1];
 
-			// The comment with the year is positioned predictably
-			let year = label.innerHTML.trim().substr(5, 4);
-			let lineColor = line.style.stroke;
-
 			// Why createElementNS? https://stackoverflow.com/a/61236874
 			let rect = this.graph.createElementNS('http://www.w3.org/2000/svg', 'rect');
 
-			rect.year = year;
+			let yearLine = new YearLine(line, label, rect);
+
+			rect.year = yearLine.year;
 			rect.setAttribute('x', patchBounds.x);
 			rect.setAttribute('y', patchBounds.y + (rectHeight * i));
 			rect.setAttribute('width', patchBounds.width);
 			rect.setAttribute('height', rectHeight);
-			rect.setAttribute('stroke-width', '1');
-			rect.setAttribute('stroke', 'black');
+			rect.setAttribute('stroke', 'none');
 			rect.setAttribute('fill', 'transparent');
 
 			rect.onclick = this.clickCallback.bind(this);
 
 			legend.appendChild(rect);
 
-			yearLines.push(new YearLine(year, lineColor, rect));
+			yearLines.push(yearLine);
 		}
 
 		return yearLines;
@@ -110,9 +107,13 @@ class GraphParser {
 }
 
 class YearLine {
-	constructor(year, lineColor, clickRect) {
-		this.year = year;
-		this.lineColor = lineColor;
+	constructor(legendLine, legendLabel, clickRect) {
+		this.legendLine = legendLine;
+		this.legendLabel = legendLabel;
+
+		this.year = legendLabel.innerHTML.trim().substr(5, 4);
+		this.lineColor = legendLine.style.stroke;
+
 		this.clickRect = clickRect;
 	}
 
@@ -122,9 +123,13 @@ class YearLine {
 
 	unfocus() {
 		this.graphLine.style.opacity = "0.1";
+		this.legendLine.style.opacity = "0.5";
+		this.legendLabel.style.opacity = "0.5";
 	}
 
 	focus() {
 		this.graphLine.style.opacity = "1";
+		this.legendLine.style.opacity = "1";
+		this.legendLabel.style.opacity = "1";
 	}
 }


### PR DESCRIPTION
Adds a little script that lets you click on the years in the legend to focus on them. It'll opacify all other years, leaving the selected year as 100% solid. Currently you cannot clear the focus to get them to all be solid again. Is that something you'd like?